### PR TITLE
Try to remove commas while string is too long

### DIFF
--- a/epub.py
+++ b/epub.py
@@ -315,6 +315,8 @@ class EPUB:
         short_def = data[0][0]
         len_ratio = 3 if lang in CJK_LANGS else 2.5
         word_id = self.lemmas[word]
+        while "," in short_def and len(short_def) / len(origin_word) > len_ratio:
+            short_def = short_def.rsplit(",", 1)[0]
         if len(short_def) / len(origin_word) > len_ratio:
             return (
                 '<a class="wordwise" epub:type="noteref" href="word_wise.xhtml#'


### PR DESCRIPTION
Definitions that are too long are currently not displayed and have to be clicked on. This PR tries to make more definitions directly visible in the text by taking the definitions that are split by commas and removing what's right to the the rightmost comma. 

I tested it a bit with my the current French ebook and found it to be a clear improvement. At least with English glosses the error rate seems to be pretty low, I couldn't find one yet, maybe with other language pairs it's more problematic.

(Of course I understand if you want to do it some other way.)