### PR TITLE
Support uv/conda environments and fix spaCy click import error

### DIFF
--- a/config.py
+++ b/config.py
@@ -18,6 +18,7 @@ from PyQt6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QFormLayout,
+    QHBoxLayout,
     QLabel,
     QLineEdit,
     QListWidget,
@@ -55,6 +56,8 @@ prefs.defaults["choose_format_manually"] = True
 prefs.defaults["gloss_lang"] = "en"
 prefs.defaults["use_wiktionary_for_kindle"] = False
 prefs.defaults["python_path"] = ""
+prefs.defaults["env_manager"] = "python"
+prefs.defaults["env_manager_path"] = ""
 prefs.defaults["show_change_kindle_ww_lang_warning"] = True
 prefs.defaults["test_wsd"] = True
 prefs.defaults["torch_compute_platform"] = "cpu"
@@ -111,16 +114,30 @@ class ConfigWidget(QWidget):
             QFormLayout.FieldGrowthPolicy.ExpandingFieldsGrow
         )
 
-        python_path_label = QLabel(_("Python path"))
-        python_path_label.setToolTip(
-            _(
-                "Absolute path of the executable binary for the Python interpreter, "
-                "leave this empty to find Python in PATH."
-            )
+        env_manager_layout = QHBoxLayout()
+        self.env_manager_box = QComboBox()
+        self.env_manager_box.addItem("Python", "python")
+        self.env_manager_box.addItem("uv", "uv")
+        self.env_manager_box.addItem("Conda", "conda")
+        
+        current_manager = prefs.get("env_manager", "python")
+        self.env_manager_box.setCurrentIndex(self.env_manager_box.findData(current_manager))
+        
+        self.env_manager_path = QLineEdit()
+        current_path = prefs.get("env_manager_path", "")
+        if not current_path and prefs.get("python_path", ""):
+            current_path = prefs.get("python_path", "")
+        self.env_manager_path.setText(current_path)
+        
+        env_manager_layout.addWidget(self.env_manager_box)
+        env_manager_layout.addWidget(self.env_manager_path)
+        
+        env_manager_label = QLabel(_("Environment manager and path"))
+        env_manager_label.setToolTip(
+            _("Select the dependency manager and provide the absolute path to its executable. "
+              "Leave path empty to find it in PATH.")
         )
-        self.python_path = QLineEdit()
-        self.python_path.setText(prefs["python_path"])
-        form_layout.addRow(python_path_label, self.python_path)
+        form_layout.addRow(env_manager_label, env_manager_layout)
 
         self.minimal_x_ray_count = QSpinBox()
         self.minimal_x_ray_count.setMinimum(1)
@@ -205,7 +222,9 @@ class ConfigWidget(QWidget):
         webbrowser.open(GITHUB_URL)
 
     def save_settings(self) -> None:
-        prefs["python_path"] = self.python_path.text()
+        prefs["env_manager"] = self.env_manager_box.currentData()
+        prefs["env_manager_path"] = self.env_manager_path.text()
+        prefs["python_path"] = self.env_manager_path.text()
         prefs["search_people"] = self.search_people_box.isChecked()
         prefs["zh_wiki_variant"] = self.zh_wiki_box.currentData()
         prefs["add_locator_map"] = self.locator_map_box.isChecked()
@@ -347,8 +366,7 @@ def dump_lemmas_job(
             "plugin_path": str(plugin_path),
             "model_name": model_name,
         }
-        args = [
-            which_python()[0],
+        args = which_python()[0] + [
             str(plugin_path),
             json.dumps(options),
             dump_prefs(prefs),

--- a/deps.py
+++ b/deps.py
@@ -19,7 +19,7 @@ from .utils import (
     run_subprocess,
 )
 
-PY_PATH = ""
+PY_CMD: list[str] = []
 LIBS_PATH = Path()
 # https://pytorch.org/get-started/locally
 PYTORCH_LINUX_PLATFORMS = {
@@ -38,11 +38,11 @@ PYTORCH_WINDOWS_PLATFORMS = {
 
 
 def install_deps(pkg: str, notif: Any) -> None:
-    global PY_PATH, LIBS_PATH
+    global PY_CMD, LIBS_PATH
     plugin_path = get_plugin_path()
 
-    if len(PY_PATH) == 0:
-        PY_PATH, py_version = which_python()
+    if len(PY_CMD) == 0:
+        PY_CMD, py_version = which_python()
         LIBS_PATH = plugin_path.parent.joinpath(f"worddumb-libs-py{py_version}")
         if not LIBS_PATH.is_dir():
             for old_libs_path in LIBS_PATH.parent.glob("worddumb-libs-py*"):
@@ -66,6 +66,7 @@ def install_deps(pkg: str, notif: Any) -> None:
     else:
         # Install X-Ray dependencies
         pip_install("rapidfuzz", dep_versions["rapidfuzz"], notif=notif)
+        pip_install("click", "", notif=notif)
         pip_install("spacy", dep_versions["spacy"], notif=notif)
         if pkg != "":
             model_version = get_spacy_model_version(pkg, dep_versions)
@@ -76,27 +77,36 @@ def install_deps(pkg: str, notif: Any) -> None:
             pip_install(pkg, model_version, url=url, notif=notif)
 
 
-def which_python() -> tuple[str, str]:
+def which_python() -> tuple[list[str], str]:
     """
     Return Python command or file path and version string
     """
     from .config import prefs
 
-    py = "python3"
-    if len(prefs["python_path"]) > 0:
-        py = prefs["python_path"]
-    elif iswindows:
-        py = "py"
-    elif ismacos:
-        py = mac_bin_path("python3")
+    manager = prefs.get("env_manager", "python")
+    path = prefs.get("env_manager_path", prefs.get("python_path", ""))
 
-    if shutil.which(py) is None:
-        raise Exception("PythonNotFound")
+    py_cmd = []
+    if manager == "uv":
+        py_cmd = [path if path else "uv", "run", "python"]
+    elif manager == "conda":
+        py_cmd = [path if path else "conda", "run", "python"]
+    else:
+        cmd = "python3"
+        if path:
+            cmd = path
+        elif iswindows:
+            cmd = "py"
+        elif ismacos:
+            cmd = mac_bin_path("python3")
+        
+        if shutil.which(cmd) is None:
+            raise Exception("PythonNotFound")
+        py_cmd = [cmd]
 
-    if isfrozen or prefs["python_path"] != "":
+    if isfrozen or path != "":
         r = run_subprocess(
-            [
-                py,
+            py_cmd + [
                 "-c",
                 'import platform; print(".".join(platform.python_version_tuple()[:2]))',
             ]
@@ -110,7 +120,7 @@ def which_python() -> tuple[str, str]:
         raise Exception("OutdatedPython")
     elif py_v_tuple > (3, 14):  # spaCy
         raise Exception("UnsupportedPython")
-    return py, py_v
+    return py_cmd, py_v
 
 
 def pip_install(
@@ -128,21 +138,38 @@ def pip_install(
         if notif:
             notif.put((0, f"Installing {pkg}"))
 
-        args = [
-            PY_PATH,
-            "-m",
-            "pip",
-            "--disable-pip-version-check",
-            "install",
-            "-U",
-            "-t",
-            str(LIBS_PATH),
-            "--no-user",  # disable "--user" option which conflicts with "-t"
-            "--no-cache-dir",
-        ]
+        from .config import prefs
+        manager = prefs.get("env_manager", "python")
+        path = prefs.get("env_manager_path", prefs.get("python_path", ""))
 
-        if no_deps:
-            args.append("--no-deps")
+        if manager == "uv":
+            args = [
+                path if path else "uv",
+                "pip",
+                "install",
+                "-U",
+                "--reinstall",
+                "--compile-bytecode",
+                "-t",
+                str(LIBS_PATH),
+                "--no-cache",
+            ]
+            if no_deps:
+                args.append("--no-deps")
+        else:
+            args = PY_CMD + [
+                "-m",
+                "pip",
+                "--disable-pip-version-check",
+                "install",
+                "-U",
+                "-t",
+                str(LIBS_PATH),
+                "--no-user",  # disable "--user" option which conflicts with "-t"
+                "--no-cache-dir",
+            ]
+            if no_deps:
+                args.append("--no-deps")
 
         if url:
             args.append(url)

--- a/parse_job.py
+++ b/parse_job.py
@@ -198,8 +198,8 @@ def do_job(
     # official calibre build: calibre's optimize level is 2 which removes docstring,
     # but the "transformers" package formats docstrings in their code
     # and calibre-debug can't be used as Python interpreter for pip
-    if isfrozen or prefs["python_path"] != "":
-        py_path, _ = which_python()
+    if isfrozen or prefs.get("env_manager_path", prefs.get("python_path", "")) != "":
+        py_cmd, _ = which_python()
         # copy data can't be converted by `asdict`
         copy_mi = data.mi
         copy_mobi_html = data.mobi_html  # bytes
@@ -208,8 +208,7 @@ def do_job(
         data.mobi_html = None
         data.kfx_json = None
         data.plugin_path = str(data.plugin_path)
-        args = [
-            py_path,
+        args = py_cmd + [
             "-I",  # isolate user env
             str(data.plugin_path),
             json.dumps(asdict(data)),

--- a/utils.py
+++ b/utils.py
@@ -32,6 +32,8 @@ class Prefs(TypedDict):
     test_wsd: bool
     torch_compute_platform: str
     custom_entity_only: bool
+    env_manager: str
+    env_manager_path: str
 
 
 def load_plugin_json(plugin_path: Path, filepath: str) -> Any:


### PR DESCRIPTION
This PR refactors the dependency management system of WordDumb to support alternative environment managers (`uv` and `Conda`) alongside the default system Python. It also fixes a dependency resolving issue with `spaCy` and improves the plugin's configuration UI.

### Key Changes
1. **Environment Manager Support (`uv` & `Conda`):**
   - Refactored `which_python()` to return a list of command arguments (`PY_CMD: list[str]`) instead of a single file path string. This allows utilizing `uv run python` or `conda run python` to run plugin tasks.
   - Updated subprocess invocations in `deps.py` and `parse_job.py` to support the command array execution.

2. **Optimized `uv` Installation Behavior:**
   - Integrated `uv pip install` command structure when `uv` is selected.
   - Appended `--reinstall` to `uv pip install` to force package installation into the target folder (`-t`). This replicates `pip install`'s behavior (ignoring pre-existing system python libraries) and avoids missing dependency errors during isolated `-I` execution.
   - Appended `--compile-bytecode` to `uv` installation commands to compile `.pyc` files upfront, matching default `pip` behavior and reducing startup latency.

3. **SpaCy Dependency Fix:**
   - Added an explicit installation of the `click` package before installing `spaCy`. 
   - *Rationale:* Modern versions of `typer` (>= 0.12) have removed `click` as a direct dependency. Because `uv` resolves dependencies strictly, `click` was not being pulled in, causing `spaCy` to fail on `import click` during runtime.

4. **UI/Configuration Enhancements:**
   - Replaced the single "Python path" text field with a unified "Environment manager and path" UI section.
   - Added a `QComboBox` to select the environment manager (`Python`, `uv`, `Conda`) and a single path text field.
   - Fully backward-compatible: existing `python_path` preferences are preserved and imported into the new manager settings automatically.